### PR TITLE
Add .swiftinterface file extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"languages": [{
 			"id": "swift",
 			"aliases": ["Swift", "swift"],
-			"extensions": [".swift"],
+			"extensions": [".swift", ".swiftinterface"],
 			"configuration": "./swift.configuration.json"
 		}],
 		"grammars": [{

--- a/syntaxes/swift.tmLanguage
+++ b/syntaxes/swift.tmLanguage
@@ -5,6 +5,7 @@
 	<key>fileTypes</key>
 	<array>
 		<string>swift</string>
+		<string>swiftinterface</string>
 	</array>
 	<key>name</key>
 	<string>Swift</string>


### PR DESCRIPTION
This PR adds the `.swiftinterface` extension to the list of supported Swift sources. 

The file type is generated by the compiler, and contains valid Swift code, kind of like a C header file.
For more info: https://forums.swift.org/t/plan-for-module-stability/14551